### PR TITLE
PRO-2138 PRO-2139: Region editor tripwire support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ A set of nodes to visualize data on the Teknoir Platform.
 npm install --save node-red-teknoir-visualize
 ```
 
+Npm install might fail for `canvas` dependency. If that happens, follow the instructions [here](https://www.npmjs.com/package/canvas)
+
 # Documentation
 The nodes are properly documented in `Node-RED` itself. 
 

--- a/src/region-editor.html
+++ b/src/region-editor.html
@@ -48,8 +48,12 @@
         </div>
     </div>
     <div className="form-row">
-        <label htmlFor="node-input-json"><i class="fa fa-tag"></i> JSON</label>
-        <textarea id="node-input-json" style="width:800px" placeholder="[]" readonly/>
+        <label htmlFor="node-input-regionsJson"><i class="fa fa-tag"></i> Regions JSON</label>
+        <textarea id="node-input-regionsJson" style="width:800px" placeholder="[]" readonly></textarea>
+    </div>
+    <div className="form-row">
+        <label htmlFor="node-input-tripwiresJson"><i class="fa fa-tag"></i> Tripwires JSON</label>
+        <textarea id="node-input-tripwiresJson" style="width:800px" placeholder="[]" readonly></textarea>
     </div>
 </script>
 
@@ -123,52 +127,68 @@
         };
     }
 
-    function collate(canvas, width, height) {
-        let objects = canvas.getObjects();
-        let objectsCount = canvas.getObjects().length;
-        let polygons = [];
-        for (var i = 0, len = objectsCount; i < len; i++) {
-            var matrix = objects[i].calcTransformMatrix();
-            let poly = [];
-            var transformedPoints = objects[i].get("points")
-                .map(function (p) {
-                    return new fabric.Point(
-                        p.x - objects[i].pathOffset.x,
-                        p.y - objects[i].pathOffset.y);
-                })
-                .map(function (p) {
-                    return fabric.util.transformPoint(p, matrix);
-                });
+    function collate(canvas, width, height, type) {
+      let objects = canvas.getObjects().filter(obj => obj.type === type);
+      let objectsCount = objects.length;
+      let polygons = [];
+      for (var i = 0; i < objectsCount; i++) {
+        var matrix = objects[i].calcTransformMatrix();
+        let poly = [];
 
-            transformedPoints.map(function (p) {
-                var pt = {
-                    x: p.x,
-                    y: p.y
-                };
-
-                poly.push(pt);
-            })
-
-            // Make unique coordinates
-            polygons[i] = _.uniqWith(poly, _.isEqual);
+        // the case for tripwires
+        if (objects[i].type === 'group') {
+          // the main tripwire line is contained in a group object as a polygon
+          let polygonObj = objects[i].getObjects().find(obj => obj.type === 'polygon');
+          if (polygonObj) {
+            poly = transformPoints(polygonObj, matrix);
+          }
+        } else {
+          poly = transformPoints(objects[i], matrix);
         }
 
-        let relativePolygons = [];
-        for (let i = 0; i < polygons.length; i++) {
-            let polygon = polygons[i]
-            let relativePolygon = [];
-            for (let i = 0; i < polygon.length; i++) {
-                relativePolygon.push(toRelative(polygon[i], width, height));
-            }
-            relativePolygons.push(relativePolygon);
-        }
+        // Make unique coordinates
+        polygons[i] = _.uniqWith(poly, _.isEqual);
+      }
 
-        return relativePolygons;
+      let relativePolygons = [];
+      for (let i = 0; i < polygons.length; i++) {
+        let polygon = polygons[i]
+        let relativePolygon = [];
+        for (let i = 0; i < polygon.length; i++) {
+          relativePolygon.push(toRelative(polygon[i], width, height));
+        }
+        relativePolygons.push(relativePolygon);
+      }
+
+      return relativePolygons;
+    }
+
+    function transformPoints(polygon, matrix) {
+      var transformedPoints = polygon.get("points")
+        .map(function (p) {
+          return new fabric.Point(
+            p.x - polygon.pathOffset.x,
+            p.y - polygon.pathOffset.y);
+        })
+        .map(function (p) {
+          return fabric.util.transformPoint(p, matrix);
+        });
+
+      let poly = []
+      transformedPoints.map(function (p) {
+        var pt = {
+          x: p.x,
+          y: p.y
+        };
+
+        poly.push(pt);
+      })
+
+      return poly;
     }
 
     RED.comms.subscribe('region-editor', function (event, msg) {
         let node = RED.nodes.node(msg.id);
-        // console.log(msg);
         node.background = msg.data;
     });
 
@@ -178,6 +198,8 @@
         defaults: {
             name: {value: ''},
             json: {value: '[]', required: true},
+            regionsJson: {value: '[]', required: true},
+            tripwiresJson: {value: '[]', required: true},
             background: {value: null, required: false},
             imageProp: {value: 'image', required: false},
             imagePropType: {value: 'msgPayload'}
@@ -212,7 +234,8 @@
 // canvas Drawing
             var node = this;
             var background = node.background || 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAgAAAAIAQMAAAD+wSzIAAAABlBMVEX///+/v7+jQ3Y5AAAADklEQVQI12P4AIX8EAgALgAD/aNpbtEAAAAASUVORK5CYII';
-            var json = node.json || '[]';
+            var regionsJson = node.regionsJson || '[]';
+            var tripwiresJson = node.tripwiresJson || '[]';
             var polygonPoints = [];
             var lines = [];
             var isDrawing = false;
@@ -235,15 +258,25 @@
                 canvas.setDimensions({width: width, height: height});
                 canvas.setBackgroundImage(background, canvas.renderAll.bind(canvas));
 
-                let polygons = JSON.parse(json);
-                for (let i = 0, len = polygons.length; i < len; i++) {
-                    let relativePolygon = polygons[i];
+                let regions = JSON.parse(regionsJson);
+                for (let i = 0, len = regions.length; i < len; i++) {
+                    let relativePolygon = regions[i];
                     let polygon = [];
                     for (let j = 0; j < relativePolygon.length; j++) {
                         polygon.push(fromRelative(relativePolygon[j], width, height));
                     }
                     canvas.add(makePolygon(polygon));
                 }
+
+                let tripwires = JSON.parse(tripwiresJson);
+              for (let i = 0, len = tripwires.length; i < len; i++) {
+                let relativeTripwire = tripwires[i];
+                let polygon = [];
+                for (let j = 0; j < relativeTripwire.length; j++) {
+                  polygon.push(fromRelative(relativeTripwire[j], width, height));
+                }
+                canvas.add(makeTripwire(polygon));
+              }
             }
 
             //
@@ -351,9 +384,6 @@
                       finalize();
                     }
                 }
-
-                // var json = document.getElementById("node-input-json");
-                // json.value = JSON.stringify(collate(this));
             });
 
             canvas.on('mouse:up', function (evt) {
@@ -364,9 +394,6 @@
                     this.isDragging = false;
                     this.selection = true;
                 }
-
-                // var json = document.getElementById("node-input-json");
-                // json.value = JSON.stringify(collate(this));
             });
 
             canvas.on('mouse:move', function (evt) {
@@ -387,9 +414,6 @@
                     }).setCoords();
                     this.renderAll();
                 }
-
-                // var json = document.getElementById("node-input-json");
-                // json.value = JSON.stringify(collate(this));
             });
 
             canvas.on('mouse:wheel', function (opt) {
@@ -410,112 +434,7 @@
             function finalize() {
               if (isDrawingTripWire) {
                 isDrawingTripWire = false;
-                let tripwire = new fabric.Line([polygonPoints[0].x, polygonPoints[0].y, polygonPoints[1].x, polygonPoints[1].y], {
-                  strokeWidth: 3,
-                  selectable: true,
-                  stroke: 'green'
-                });
-
-                let tripwireArrowAngle = Math.atan2(polygonPoints[1].y - polygonPoints[0].y, polygonPoints[1].x - polygonPoints[0].x) * (180 / Math.PI);
-                let tripwireArrowHead = new fabric.Triangle({
-                  left: polygonPoints[1].x,
-                  top: polygonPoints[1].y,
-                  originX: 'center',
-                  originY: 'center',
-                  angle: tripwireArrowAngle + 90, // Adjust the angle to point correctly
-                  width: 10,
-                  height: 15,
-                  fill: 'green'
-                });
-
-                // Calculate the middle point of the tripwire. This is going to be a reference point for the entry and exit vectors
-                let midPoint = new fabric.Point((polygonPoints[0].x + polygonPoints[1].x) / 2, (polygonPoints[0].y + polygonPoints[1].y) / 2);
-
-                // Calculate the direction vector from the start point to the end point
-                let dirVector = new fabric.Point(polygonPoints[1].x - polygonPoints[0].x, polygonPoints[1].y - polygonPoints[0].y);
-
-                // Calculate the perpendicular vectors to the direction vector (tripwire)
-                let perpVector1 = new fabric.Point(-dirVector.y, dirVector.x);
-                let perpVector2 = new fabric.Point(dirVector.y, -dirVector.x);
-
-                // Normalize the vectors for entry/exit display
-                let magnitude1 = Math.sqrt(perpVector1.x * perpVector1.x + perpVector1.y * perpVector1.y);
-                let magnitude2 = Math.sqrt(perpVector2.x * perpVector2.x + perpVector2.y * perpVector2.y);
-                let normalizedPerpVector1 = new fabric.Point(perpVector1.x / magnitude1, perpVector1.y / magnitude1);
-                let normalizedPerpVector2 = new fabric.Point(perpVector2.x / magnitude2, perpVector2.y / magnitude2);
-
-                // Length of the arrow
-                let arrowLength = 30;
-
-                // Offset for arrow tip from midpoint
-                let arrowOffset = 10;
-
-                // Calculate the entry and exit points
-                let exitPoint = new fabric.Point(midPoint.x + normalizedPerpVector1.x * arrowLength, midPoint.y + normalizedPerpVector1.y * arrowLength);
-                let entryPoint = new fabric.Point(midPoint.x + normalizedPerpVector2.x * arrowLength, midPoint.y + normalizedPerpVector2.y * arrowLength);
-
-                // Draw the vectors on the canvas
-                let entryVector = new fabric.Polyline([{x: midPoint.x, y: midPoint.y}, {x: entryPoint.x, y: entryPoint.y}], {
-                  stroke: 'red',
-                  strokeWidth: 2,
-                  selectable: false
-                });
-                let exitVector = new fabric.Polyline([{x: midPoint.x, y: midPoint.y}, {x: exitPoint.x, y: exitPoint.y}], {
-                  stroke: 'red',
-                  strokeWidth: 2,
-                  selectable: false
-                });
-
-                // Add the text "Entry" and "Exit" next to the vectors
-                let entryText = new fabric.Text("Entry", {
-                  left: entryPoint.x,
-                  top: entryPoint.y,
-                  fontSize: 20,
-                  fill: 'red'
-                });
-                let exitText = new fabric.Text("Exit", {
-                  left: exitPoint.x,
-                  top: exitPoint.y,
-                  fontSize: 20,
-                  fill: 'red'
-                });
-
-                // Calculate positions for the arrowheads with offset
-                let adjustedEntryPoint = new fabric.Point(midPoint.x - normalizedPerpVector2.x * arrowOffset, midPoint.y - normalizedPerpVector2.y * arrowOffset);
-                let adjustedExitPoint = new fabric.Point(midPoint.x - normalizedPerpVector1.x * arrowOffset, midPoint.y - normalizedPerpVector1.y * arrowOffset);
-
-                // Add arrowheads to the vectors
-                let entryArrowAngle = Math.atan2(midPoint.y - entryPoint.y, midPoint.x - entryPoint.x) * (180 / Math.PI);
-                let entryArrowHead = new fabric.Triangle({
-                  left: adjustedExitPoint.x,
-                  top: adjustedExitPoint.y,
-                  originX: 'center',
-                  originY: 'center',
-                  angle: entryArrowAngle + 90, // Adjust the angle to point correctly
-                  width: 10,
-                  height: 15,
-                  fill: 'red'
-                });
-
-                let exitArrowAngle = Math.atan2(midPoint.y - exitPoint.y, midPoint.x - exitPoint.x) * (180 / Math.PI);
-                let exitArrowHead = new fabric.Triangle({
-                  left: adjustedEntryPoint.x,
-                  top: adjustedEntryPoint.y,
-                  originX: 'center',
-                  originY: 'center',
-                  angle: exitArrowAngle + 90, // Adjust the angle to point correctly
-                  width: 10,
-                  height: 15,
-                  fill: 'red'
-                });
-
-                // Create the entire group so that we can move the entire tripwire as a single entity
-                let tripwireGroup = new fabric.Group([tripwire, tripwireArrowHead, entryVector, exitVector, entryArrowHead, exitArrowHead, entryText, exitText], {
-                  selectable: true // Make the group selectable
-                });
-
-                // Add the group to the canvas
-                canvas.add(tripwireGroup);
+                canvas.add(makeTripwire(polygonPoints));
               } else if (isDrawing) {
                 isDrawing = false;
                 canvas.add(makePolygon(polygonPoints)).renderAll();
@@ -531,8 +450,112 @@
               polygonPoints.length = 0;
             }
 
+            function makeTripwire(polygonPoints) {
+              let tripwire = new fabric.Polygon(polygonPoints.slice(), {
+                strokeWidth: 3,
+                selectable: true,
+                stroke: 'green'
+              });
 
-//
+              let tripwireArrowAngle = Math.atan2(polygonPoints[1].y - polygonPoints[0].y, polygonPoints[1].x - polygonPoints[0].x) * (180 / Math.PI);
+              let tripwireArrowHead = new fabric.Triangle({
+                left: polygonPoints[1].x,
+                top: polygonPoints[1].y,
+                originX: 'center',
+                originY: 'center',
+                angle: tripwireArrowAngle + 90, // Adjust the angle to point correctly
+                width: 10,
+                height: 15,
+                fill: 'green'
+              });
+
+              // Calculate the middle point of the tripwire. This is going to be a reference point for the entry and exit vectors
+              let midPoint = new fabric.Point((polygonPoints[0].x + polygonPoints[1].x) / 2, (polygonPoints[0].y + polygonPoints[1].y) / 2);
+
+              // Calculate the direction vector from the start point to the end point
+              let dirVector = new fabric.Point(polygonPoints[1].x - polygonPoints[0].x, polygonPoints[1].y - polygonPoints[0].y);
+
+              // Calculate the perpendicular vectors to the direction vector (tripwire)
+              let perpVector1 = new fabric.Point(-dirVector.y, dirVector.x);
+              let perpVector2 = new fabric.Point(dirVector.y, -dirVector.x);
+
+              // Normalize the vectors for entry/exit display
+              let magnitude1 = Math.sqrt(perpVector1.x * perpVector1.x + perpVector1.y * perpVector1.y);
+              let magnitude2 = Math.sqrt(perpVector2.x * perpVector2.x + perpVector2.y * perpVector2.y);
+              let normalizedPerpVector1 = new fabric.Point(perpVector1.x / magnitude1, perpVector1.y / magnitude1);
+              let normalizedPerpVector2 = new fabric.Point(perpVector2.x / magnitude2, perpVector2.y / magnitude2);
+
+              // Length of the arrow
+              let arrowLength = 30;
+
+              // Offset for arrow tip from midpoint
+              let arrowOffset = 10;
+
+              // Calculate the entry and exit points
+              let exitPoint = new fabric.Point(midPoint.x + normalizedPerpVector1.x * arrowLength, midPoint.y + normalizedPerpVector1.y * arrowLength);
+              let entryPoint = new fabric.Point(midPoint.x + normalizedPerpVector2.x * arrowLength, midPoint.y + normalizedPerpVector2.y * arrowLength);
+
+              // Draw the vectors on the canvas
+              let entryVector = new fabric.Polyline([{x: midPoint.x, y: midPoint.y}, {x: entryPoint.x, y: entryPoint.y}], {
+                stroke: 'red',
+                strokeWidth: 2,
+                selectable: false
+              });
+              let exitVector = new fabric.Polyline([{x: midPoint.x, y: midPoint.y}, {x: exitPoint.x, y: exitPoint.y}], {
+                stroke: 'red',
+                strokeWidth: 2,
+                selectable: false
+              });
+
+              // Add the text "Entry" and "Exit" next to the vectors
+              let entryText = new fabric.Text("Entry", {
+                left: entryPoint.x,
+                top: entryPoint.y,
+                fontSize: 20,
+                fill: 'red'
+              });
+              let exitText = new fabric.Text("Exit", {
+                left: exitPoint.x,
+                top: exitPoint.y,
+                fontSize: 20,
+                fill: 'red'
+              });
+
+              // Calculate positions for the arrowheads with offset
+              let adjustedEntryPoint = new fabric.Point(midPoint.x - normalizedPerpVector2.x * arrowOffset, midPoint.y - normalizedPerpVector2.y * arrowOffset);
+              let adjustedExitPoint = new fabric.Point(midPoint.x - normalizedPerpVector1.x * arrowOffset, midPoint.y - normalizedPerpVector1.y * arrowOffset);
+
+              // Add arrowheads to the vectors
+              let entryArrowAngle = Math.atan2(midPoint.y - entryPoint.y, midPoint.x - entryPoint.x) * (180 / Math.PI);
+              let entryArrowHead = new fabric.Triangle({
+                left: adjustedExitPoint.x,
+                top: adjustedExitPoint.y,
+                originX: 'center',
+                originY: 'center',
+                angle: entryArrowAngle + 90, // Adjust the angle to point correctly
+                width: 10,
+                height: 15,
+                fill: 'red'
+              });
+
+              let exitArrowAngle = Math.atan2(midPoint.y - exitPoint.y, midPoint.x - exitPoint.x) * (180 / Math.PI);
+              let exitArrowHead = new fabric.Triangle({
+                left: adjustedEntryPoint.x,
+                top: adjustedEntryPoint.y,
+                originX: 'center',
+                originY: 'center',
+                angle: exitArrowAngle + 90, // Adjust the angle to point correctly
+                width: 10,
+                height: 15,
+                fill: 'red'
+              });
+
+              // Create the entire group so that we can move the entire tripwire as a single entity
+              return new fabric.Group([tripwire, tripwireArrowHead, entryVector, exitVector, entryArrowHead, exitArrowHead, entryText, exitText], {
+                selectable: true // Make the group selectable
+              });
+            }
+
             function makePolygon(polygonPoints) {
 
                 var left = fabric.util.array.min(polygonPoints, "x");
@@ -613,9 +636,13 @@
             }
         },
         oneditsave: function () {
-            this.json = JSON.stringify(collate(this.canvas, this.width, this.height));
-            var json = document.getElementById("node-input-json");
-            json.value = this.json;
+            this.regionsJson = JSON.stringify(collate(this.canvas, this.width, this.height, 'polygon'));
+            var textAreaRegionsJson = document.getElementById("node-input-regionsJson");
+            textAreaRegionsJson.value = this.regionsJson;
+
+            this.tripwiresJson = JSON.stringify(collate(this.canvas, this.width, this.height, 'group'));
+            var textAreaTripwiresJson = document.getElementById("node-input-tripwiresJson");
+            textAreaTripwiresJson.value = this.tripwiresJson;
 
             this.canvas = null;
         },

--- a/src/region-editor.html
+++ b/src/region-editor.html
@@ -24,20 +24,9 @@
     <div className="form-row">
         <label htmlFor="node-canvas"><i class="fa fa-tag"></i> Canvas</label>
         <ul id="node-canvas" style="display:inline-block">
-            <li id="add" class="red-ui-typedInput-container"
-                style="display:inline-block;padding:5px 10px;margin-right:-1px;cursor:pointer"><i class="fa fa-plus"
-                                                                                                  title="New poly"></i>
-                <!--            <li id="pencil" class="red-ui-typedInput-container" style="display:inline-block;padding:5px 10px;margin-right:-1px;cursor:pointer"><i class="fa fa-pencil" title="L: Line"></i>-->
-                <!--            <li id="arrows" class="red-ui-typedInput-container" style="display:inline-block;padding:5px 10px;margin-right:-1px;cursor:pointer"><i class="fa fa-arrows" title="M: Move"></i>-->
-            <li id="edit" class="red-ui-typedInput-container"
-                style="display:inline-block;padding:5px 10px;margin-right:-1px;cursor:pointer"><i class="fa fa-edit"
-                                                                                                  title="Edit selected poly"></i>
-                <!--            <li id="plus" class="red-ui-typedInput-container" style="display:inline-block;padding:5px 10px;margin-right:-1px;cursor:pointer"><i class="fa fa-plus" title="A: Add"></i>-->
-                <!--            <li id="scissors" class="red-ui-typedInput-container" style="display:inline-block;padding:5px 10px;margin-right:-1px;cursor:pointer"><i class="fa fa-scissors" title="C: Cut"></i>-->
-                <!--            <li id="crosshairs" class="red-ui-typedInput-container" style="display:inline-block;padding:5px 10px;margin-right:-1px;cursor:pointer"><i class="fa fa-crosshairs" title="O: Change Origin"></i>-->
-                <!--            <li id="eye-slash" class="red-ui-typedInput-container" style="display:inline-block;padding:5px 10px;margin-right:-1px;cursor:pointer"><i class="fa fa-eye-slash" title="V: Toggle Visibility"></i>-->
-                <!--            <li id="anchor" class="red-ui-typedInput-container" style="display:inline-block;padding:5px 10px;margin-right:-1px;cursor:pointer"><i class="fa fa-anchor" title="S: Toggle Grid Snap"></i>-->
-            </li>
+            <li id="add" class="red-ui-typedInput-container" style="display:inline-block;padding:5px 10px;margin-right:-1px;cursor:pointer"><i class="fa fa-area-chart" title="New poly"></i>
+            <li id="add-tripwire" class="red-ui-typedInput-container" style="display:inline-block;padding:5px 10px;margin-right:-1px;cursor:pointer"><i class="fa fa-arrow-right " title="New tripwire"></i>
+            <li id="edit" class="red-ui-typedInput-container" style="display:inline-block;padding:5px 10px;margin-right:-1px;cursor:pointer"><i class="fa fa-edit" title="Edit selected poly"></i></li>
         </ul>
         <ul style="display:inline-block">
             <!--            <li id="undo" class="red-ui-typedInput-container" style="display:inline-block;padding:5px 10px;margin-right:-1px;cursor:pointer"><i class="fa fa-undo" title="U: Undo"></i>-->
@@ -227,6 +216,7 @@
             var polygonPoints = [];
             var lines = [];
             var isDrawing = false;
+            var isDrawingTripWire = false;
             if (!node.canvas) {
                 node.canvas = new fabric.Canvas('polyCanvas')
             }
@@ -264,6 +254,19 @@
                     isDrawing = true;
                 }
             };
+
+          document.getElementById("add-tripwire").onclick = function () {
+            if (isDrawingTripWire) {
+              finalize();
+            } else {
+              isDrawingTripWire = true;
+
+              // reset the polygon drawing state
+              isDrawing = false;
+              polygonPoints.length = 0;
+              lines.length = 0;
+            }
+          };
 
             //
             document.getElementById("edit").onclick = function () {
@@ -327,14 +330,14 @@
                     this.lastPosX = evt.e.clientX;
                     this.lastPosY = evt.e.clientY;
                 }
-                if (isDrawing) {
+                if (isDrawing || isDrawingTripWire) {
                     var _mouse = this.getPointer(evt.e);
                     var _x = _mouse.x;
                     var _y = _mouse.y;
                     var line = new fabric.Line([_x, _y, _x, _y], {
                         strokeWidth: 1,
                         selectable: false,
-                        stroke: 'red'
+                        stroke: isDrawing ? 'red' : 'green'
                     });
 
                     polygonPoints.push(new fabric.Point(_x, _y));
@@ -342,6 +345,11 @@
 
                     this.add(line);
                     this.selection = false;
+
+                    // finalize the drawing for tripwire if we have 2 points
+                    if (isDrawingTripWire && polygonPoints.length === 2) {
+                      finalize();
+                    }
                 }
 
                 // var json = document.getElementById("node-input-json");
@@ -371,7 +379,7 @@
                     this.lastPosX = e.clientX;
                     this.lastPosY = e.clientY;
                 }
-                if (lines.length && isDrawing) {
+                if (lines.length && (isDrawing || isDrawingTripWire)) {
                     var _mouse = this.getPointer(evt.e);
                     lines[lines.length - 1].set({
                         x2: _mouse.x,
@@ -400,16 +408,123 @@
 
 //
             function finalize() {
-                isDrawing = false;
-
-                lines.forEach(function (line) {
-                    canvas.remove(line);
+              if (isDrawingTripWire) {
+                isDrawingTripWire = false;
+                let tripwire = new fabric.Line([polygonPoints[0].x, polygonPoints[0].y, polygonPoints[1].x, polygonPoints[1].y], {
+                  strokeWidth: 3,
+                  selectable: true,
+                  stroke: 'green'
                 });
 
+                let tripwireArrowAngle = Math.atan2(polygonPoints[1].y - polygonPoints[0].y, polygonPoints[1].x - polygonPoints[0].x) * (180 / Math.PI);
+                let tripwireArrowHead = new fabric.Triangle({
+                  left: polygonPoints[1].x,
+                  top: polygonPoints[1].y,
+                  originX: 'center',
+                  originY: 'center',
+                  angle: tripwireArrowAngle + 90, // Adjust the angle to point correctly
+                  width: 10,
+                  height: 15,
+                  fill: 'green'
+                });
+                canvas.add(tripwire);
+                canvas.add(tripwireArrowHead);
+
+                // Calculate the middle point of the tripwire. This is going to be a reference point for the entry and exit vectors
+                let midPoint = new fabric.Point((polygonPoints[0].x + polygonPoints[1].x) / 2, (polygonPoints[0].y + polygonPoints[1].y) / 2);
+
+                // Calculate the direction vector from the start point to the end point
+                let dirVector = new fabric.Point(polygonPoints[1].x - polygonPoints[0].x, polygonPoints[1].y - polygonPoints[0].y);
+
+                // Calculate the perpendicular vectors to the direction vector (tripwire)
+                let perpVector1 = new fabric.Point(-dirVector.y, dirVector.x);
+                let perpVector2 = new fabric.Point(dirVector.y, -dirVector.x);
+
+                // Normalize the vectors for entry/exit display
+                let magnitude1 = Math.sqrt(perpVector1.x * perpVector1.x + perpVector1.y * perpVector1.y);
+                let magnitude2 = Math.sqrt(perpVector2.x * perpVector2.x + perpVector2.y * perpVector2.y);
+                let normalizedPerpVector1 = new fabric.Point(perpVector1.x / magnitude1, perpVector1.y / magnitude1);
+                let normalizedPerpVector2 = new fabric.Point(perpVector2.x / magnitude2, perpVector2.y / magnitude2);
+
+                // Calculate the entry and exit points
+                let arrowLength = 30; // Length of the arrow
+                let arrowOffset = 10; // Offset for arrow tip from midpoint
+                let exitPoint = new fabric.Point(midPoint.x + normalizedPerpVector1.x * arrowLength, midPoint.y + normalizedPerpVector1.y * arrowLength);
+                let entryPoint = new fabric.Point(midPoint.x + normalizedPerpVector2.x * arrowLength, midPoint.y + normalizedPerpVector2.y * arrowLength);
+
+                // Draw the vectors on the canvas
+                let entryVector = new fabric.Line([midPoint.x, midPoint.y, entryPoint.x, entryPoint.y], {
+                  stroke: 'red',
+                  strokeWidth: 2,
+                  selectable: false
+                });
+                let exitVector = new fabric.Line([midPoint.x, midPoint.y, exitPoint.x, exitPoint.y], {
+                  stroke: 'red',
+                  strokeWidth: 2,
+                  selectable: false
+                });
+                canvas.add(entryVector);
+                canvas.add(exitVector);
+
+                // Add the text "Entry" and "Exit" next to the vectors
+                let entryText = new fabric.Text("Entry", {
+                  left: entryPoint.x,
+                  top: entryPoint.y,
+                  fontSize: 20,
+                  fill: 'red'
+                });
+                let exitText = new fabric.Text("Exit", {
+                  left: exitPoint.x,
+                  top: exitPoint.y,
+                  fontSize: 20,
+                  fill: 'red'
+                });
+                canvas.add(entryText);
+                canvas.add(exitText);
+
+                // Calculate positions for the arrowheads with offset
+                let adjustedEntryPoint = new fabric.Point(midPoint.x - normalizedPerpVector2.x * arrowOffset, midPoint.y - normalizedPerpVector2.y * arrowOffset);
+                let adjustedExitPoint = new fabric.Point(midPoint.x - normalizedPerpVector1.x * arrowOffset, midPoint.y - normalizedPerpVector1.y * arrowOffset);
+
+                // Add arrowheads to the vectors
+                let arrowAngle1 = Math.atan2(midPoint.y - entryPoint.y, midPoint.x - entryPoint.x) * (180 / Math.PI);
+                let arrowHead1 = new fabric.Triangle({
+                  left: adjustedExitPoint.x,
+                  top: adjustedExitPoint.y,
+                  originX: 'center',
+                  originY: 'center',
+                  angle: arrowAngle1 + 90, // Adjust the angle to point correctly
+                  width: 10,
+                  height: 15,
+                  fill: 'red'
+                });
+                canvas.add(arrowHead1);
+
+                let arrowAngle2 = Math.atan2(midPoint.y - exitPoint.y, midPoint.x - exitPoint.x) * (180 / Math.PI);
+                let arrowHead2 = new fabric.Triangle({
+                  left: adjustedEntryPoint.x,
+                  top: adjustedEntryPoint.y,
+                  originX: 'center',
+                  originY: 'center',
+                  angle: arrowAngle2 + 90, // Adjust the angle to point correctly
+                  width: 10,
+                  height: 15,
+                  fill: 'red'
+                });
+                canvas.add(arrowHead2);
+              } else if (isDrawing) {
+                isDrawing = false;
                 canvas.add(makePolygon(polygonPoints)).renderAll();
-                canvas.selection = true;
-                lines.length = 0;
-                polygonPoints.length = 0;
+              }
+
+              canvas.selection = true;
+
+              lines.forEach(function (line) {
+                canvas.remove(line);
+              });
+
+              lines.length = 0;
+              polygonPoints.length = 0;
             }
 
 

--- a/src/region-editor.html
+++ b/src/region-editor.html
@@ -1,12 +1,12 @@
-<script src="https://cdnjs.cloudflare.com/ajax/libs/fabric.js/5.2.4/fabric.min.js"
+<script crossorigin="anonymous"
         integrity="sha512-HkRNCiaZYxQAkHpLFYI90ObSzL0vaIXL8Xe3bM51vhdYI79RDFMLTAsmVH1xVPREmTlUWexgrQMk+c3RBTsLGw=="
-        crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+        referrerpolicy="no-referrer" src="https://cdnjs.cloudflare.com/ajax/libs/fabric.js/5.2.4/fabric.min.js"></script>
 
-<script src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.21/lodash.min.js"
+<script crossorigin="anonymous"
         integrity="sha512-WFN04846sdKMIP5LKNphMaWzU7YpMyCU245etK3g/2ARYbPK9Ub18eG+ljU96qKRCWh+quCY7yefSmlkQw1ANQ=="
-        crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+        referrerpolicy="no-referrer" src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.21/lodash.min.js"></script>
 
-<script type="text/html" data-template-name="region-editor">
+<script data-template-name="region-editor" type="text/html">
     <div className="form-row">
         <label htmlFor="node-input-name"><i class="fa fa-tag"></i> Name</label>
         <input type="text" id="node-input-name" placeholder="Name">
@@ -17,20 +17,21 @@
         <input type="hidden" id="node-input-imagePropType">
     </div>
     <hr align="middle"/>
-    <!--    <div className="form-row">-->
-    <!--        <label htmlFor="node-input-zoom"><i className="fa fa-tag"></i> Zoom</label>-->
-    <!--        <input lass="red-ui-typedInput-container" id="node-input-zoom" style="width:100%" type="range" name="zoom" min="5" max="40">-->
-    <!--    </div>-->
     <div className="form-row">
         <label htmlFor="node-canvas"><i class="fa fa-tag"></i> Canvas</label>
         <ul id="node-canvas" style="display:inline-block">
-            <li id="add" class="red-ui-typedInput-container" style="display:inline-block;padding:5px 10px;margin-right:-1px;cursor:pointer"><i class="fa fa-area-chart" title="New poly"></i>
-            <li id="add-tripwire" class="red-ui-typedInput-container" style="display:inline-block;padding:5px 10px;margin-right:-1px;cursor:pointer"><i class="fa fa-arrow-right " title="New tripwire"></i>
-            <li id="edit" class="red-ui-typedInput-container" style="display:inline-block;padding:5px 10px;margin-right:-1px;cursor:pointer"><i class="fa fa-edit" title="Edit selected poly"></i></li>
+            <li id="add" class="red-ui-typedInput-container"
+                style="display:inline-block;padding:5px 10px;margin-right:-1px;cursor:pointer"><i
+                    class="fa fa-area-chart" title="New poly"></i>
+            <li id="add-tripwire" class="red-ui-typedInput-container"
+                style="display:inline-block;padding:5px 10px;margin-right:-1px;cursor:pointer"><i
+                    class="fa fa-arrow-right " title="New tripwire"></i>
+            <li id="edit" class="red-ui-typedInput-container"
+                style="display:inline-block;padding:5px 10px;margin-right:-1px;cursor:pointer"><i class="fa fa-edit"
+                                                                                                  title="Edit selected poly"></i>
+            </li>
         </ul>
         <ul style="display:inline-block">
-            <!--            <li id="undo" class="red-ui-typedInput-container" style="display:inline-block;padding:5px 10px;margin-right:-1px;cursor:pointer"><i class="fa fa-undo" title="U: Undo"></i>-->
-            <!--            <li id="redo" class="red-ui-typedInput-container" style="display:inline-block;padding:5px 10px;margin-right:-1px;cursor:pointer"><i class="fa fa-repeat" title="R: Redo"></i>-->
             <li id="trash" class="red-ui-typedInput-container"
                 style="display:inline-block;padding:5px 10px;margin-right:-1px;cursor:pointer"><i class="fa fa-trash-o"
                                                                                                   title="Delete All"></i>
@@ -57,7 +58,7 @@
     </div>
 </script>
 
-<script type="text/html" data-help-name="region-editor">
+<script data-help-name="region-editor" type="text/html">
     <p>
         Draw regions in an image.
     </p>
@@ -105,7 +106,7 @@
 }
     </code></pre>
 </script>
-<script type="text/html" data-template-name="region-editor">
+<script data-template-name="region-editor" type="text/html">
     $("#node-input-example1").typedInput({
     type:"str",
     types:["str","num","bool"],
@@ -113,541 +114,536 @@
     })
 </script>
 <script type="text/javascript">
-    function fromRelative(point, width, height) {
-        return {
-            x: point.x * width,
-            y: point.y * height
-        };
+  function fromRelative(point, width, height) {
+    return {
+      x: point.x * width,
+      y: point.y * height
+    };
+  }
+
+  function toRelative(point, width, height) {
+    return {
+      x: point.x / parseFloat(width),
+      y: point.y / parseFloat(height)
+    };
+  }
+
+  function collate(canvas, width, height, type) {
+    let objects = canvas.getObjects().filter(obj => obj.type === type);
+    let objectsCount = objects.length;
+    let polygons = [];
+    for (var i = 0; i < objectsCount; i++) {
+      var matrix = objects[i].calcTransformMatrix();
+      let poly = [];
+
+      // the case for tripwires
+      if (objects[i].type === 'group') {
+        // the main tripwire line is contained in a group object as a polygon
+        let polygonObj = objects[i].getObjects().find(obj => obj.type === 'polygon');
+        if (polygonObj) {
+          poly = transformPoints(polygonObj, matrix);
+        }
+      } else {
+        poly = transformPoints(objects[i], matrix);
+      }
+
+      // Make unique coordinates
+      polygons[i] = _.uniqWith(poly, _.isEqual);
     }
 
-    function toRelative(point, width, height) {
-        return {
-            x: point.x / parseFloat(width),
-            y: point.y / parseFloat(height)
-        };
+    let relativePolygons = [];
+    for (let i = 0; i < polygons.length; i++) {
+      let polygon = polygons[i]
+      let relativePolygon = [];
+      for (let i = 0; i < polygon.length; i++) {
+        relativePolygon.push(toRelative(polygon[i], width, height));
+      }
+      relativePolygons.push(relativePolygon);
     }
 
-    function collate(canvas, width, height, type) {
-      let objects = canvas.getObjects().filter(obj => obj.type === type);
-      let objectsCount = objects.length;
-      let polygons = [];
-      for (var i = 0; i < objectsCount; i++) {
-        var matrix = objects[i].calcTransformMatrix();
-        let poly = [];
+    return relativePolygons;
+  }
 
-        // the case for tripwires
-        if (objects[i].type === 'group') {
-          // the main tripwire line is contained in a group object as a polygon
-          let polygonObj = objects[i].getObjects().find(obj => obj.type === 'polygon');
-          if (polygonObj) {
-            poly = transformPoints(polygonObj, matrix);
+  function transformPoints(polygon, matrix) {
+    var transformedPoints = polygon.get("points")
+      .map(function (p) {
+        return new fabric.Point(
+          p.x - polygon.pathOffset.x,
+          p.y - polygon.pathOffset.y);
+      })
+      .map(function (p) {
+        return fabric.util.transformPoint(p, matrix);
+      });
+
+    let poly = []
+    transformedPoints.map(function (p) {
+      var pt = {
+        x: p.x,
+        y: p.y
+      };
+
+      poly.push(pt);
+    })
+
+    return poly;
+  }
+
+  RED.comms.subscribe('region-editor', function (event, msg) {
+    let node = RED.nodes.node(msg.id);
+    node.background = msg.data;
+  });
+
+  RED.nodes.registerType('region-editor', {
+    category: 'visualize',
+    color: '#F3B567',
+    defaults: {
+      name: {value: ''},
+      json: {value: '[]', required: true},
+      regionsJson: {value: '[]', required: true},
+      tripwiresJson: {value: '[]', required: true},
+      background: {value: null, required: false},
+      imageProp: {value: 'image', required: false},
+      imagePropType: {value: 'msgPayload'}
+    },
+    inputs: 1,
+    outputs: 1,
+    icon: 'tn_dark.svg',
+    label: function () {
+      return this.name || 'region editor';
+    },
+    labelStyle: function () {
+      return this.name ? "node_label_italic" : "";
+    },
+    oneditprepare: function () {
+      const msgPayload = {
+        value: "msgPayload",
+        label: "msg.payload."
+      };
+      const msgEvent = {
+        value: "msgEvent",
+        label: "msg.payload.event."
+      };
+      $("#node-input-imageProp").typedInput({
+        default: "msgPayload",
+        types: ['msg', msgPayload, msgEvent],
+        typeField: "#node-input-imagePropType"
+      });
+      if (!$("#node-input-imageProp").typedInput('value').length) {
+        $("#node-input-imageProp").typedInput('type', 'msgEvent');
+        $("#node-input-imageProp").typedInput('value', 'image');
+      }
+// canvas Drawing
+      var node = this;
+      var background = node.background || 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAgAAAAIAQMAAAD+wSzIAAAABlBMVEX///+/v7+jQ3Y5AAAADklEQVQI12P4AIX8EAgALgAD/aNpbtEAAAAASUVORK5CYII';
+      var regionsJson = node.regionsJson || '[]';
+      var tripwiresJson = node.tripwiresJson || '[]';
+      var polygonPoints = [];
+      var lines = [];
+      var isDrawing = false;
+      var isDrawingTripWire = false;
+      if (!node.canvas) {
+        node.canvas = new fabric.Canvas('polyCanvas')
+      }
+      let canvas = node.canvas;
+      node.width = node.width || 800;
+      node.height = node.height || 600;
+      let width = node.width;
+      let height = node.height;
+
+      const img = new Image(background);
+      img.src = background;
+      img.onload = function () {
+        node.width = width = img.naturalWidth;
+        node.height = height = img.naturalHeight;
+
+        canvas.setDimensions({width: width, height: height});
+        canvas.setBackgroundImage(background, canvas.renderAll.bind(canvas));
+
+        let regions = JSON.parse(regionsJson);
+        for (let i = 0, len = regions.length; i < len; i++) {
+          let relativePolygon = regions[i];
+          let polygon = [];
+          for (let j = 0; j < relativePolygon.length; j++) {
+            polygon.push(fromRelative(relativePolygon[j], width, height));
           }
+          canvas.add(makePolygon(polygon));
+        }
+
+        let tripwires = JSON.parse(tripwiresJson);
+        for (let i = 0, len = tripwires.length; i < len; i++) {
+          let relativeTripwire = tripwires[i];
+          let polygon = [];
+          for (let j = 0; j < relativeTripwire.length; j++) {
+            polygon.push(fromRelative(relativeTripwire[j], width, height));
+          }
+          canvas.add(makeTripwire(polygon));
+        }
+      }
+
+      document.getElementById("add").onclick = function () {
+        if (isDrawing) {
+          finalize();
         } else {
-          poly = transformPoints(objects[i], matrix);
+          isDrawing = true;
+        }
+      };
+
+      document.getElementById("add-tripwire").onclick = function () {
+        if (isDrawingTripWire) {
+          finalize();
+        } else {
+          isDrawingTripWire = true;
+
+          // reset the polygon drawing state
+          isDrawing = false;
+          polygonPoints.length = 0;
+          lines.length = 0;
+        }
+      };
+
+      document.getElementById("edit").onclick = function () {
+        if (!canvas.getActiveObject()) {
+          return;
         }
 
-        // Make unique coordinates
-        polygons[i] = _.uniqWith(poly, _.isEqual);
-      }
-
-      let relativePolygons = [];
-      for (let i = 0; i < polygons.length; i++) {
-        let polygon = polygons[i]
-        let relativePolygon = [];
-        for (let i = 0; i < polygon.length; i++) {
-          relativePolygon.push(toRelative(polygon[i], width, height));
+        var poly = canvas.getActiveObject();
+        canvas.setActiveObject(poly);
+        poly.edit = !poly.edit;
+        if (poly.edit) {
+          var lastControl = poly.points.length - 1;
+          poly.cornerStyle = 'circle';
+          poly.cornerColor = 'rgba(0,0,255,0.5)';
+          poly.controls = poly.points.reduce(function (acc, point, index) {
+            acc['p' + index] = new fabric.Control({
+              positionHandler: polygonPositionHandler,
+              actionHandler: anchorWrapper(index > 0 ? index - 1 : lastControl, actionHandler),
+              actionName: 'modifyPolygon',
+              pointIndex: index
+            });
+            return acc;
+          }, {});
+        } else {
+          poly.cornerColor = 'blue';
+          poly.cornerStyle = 'rect';
+          poly.controls = fabric.Object.prototype.controls;
         }
-        relativePolygons.push(relativePolygon);
+        poly.hasBorders = !poly.edit;
+        canvas.requestRenderAll();
       }
 
-      return relativePolygons;
-    }
+      document.getElementById("trash").onclick = function () {
+        if (!canvas.getActiveObject()) {
+          return;
+        }
 
-    function transformPoints(polygon, matrix) {
-      var transformedPoints = polygon.get("points")
-        .map(function (p) {
-          return new fabric.Point(
-            p.x - polygon.pathOffset.x,
-            p.y - polygon.pathOffset.y);
-        })
-        .map(function (p) {
-          return fabric.util.transformPoint(p, matrix);
+        var poly = canvas.getActiveObject();
+        canvas.remove(poly);
+      };
+
+      fabric.util.addListener(window, "dblclick", function () {
+        if (isDrawing) {
+          finalize();
+        }
+      });
+
+      fabric.util.addListener(window, "keyup", function (evt) {
+        if (evt.which === 13 && isDrawing) {
+          finalize();
+        }
+      });
+
+      canvas.on('mouse:down', function (evt) {
+        if (evt.e.altKey === true) {
+          this.isDragging = true;
+          this.selection = false;
+          this.lastPosX = evt.e.clientX;
+          this.lastPosY = evt.e.clientY;
+        }
+        if (isDrawing || isDrawingTripWire) {
+          var _mouse = this.getPointer(evt.e);
+          var _x = _mouse.x;
+          var _y = _mouse.y;
+          var line = new fabric.Line([_x, _y, _x, _y], {
+            strokeWidth: 1,
+            selectable: false,
+            stroke: isDrawing ? 'red' : 'green'
+          });
+
+          polygonPoints.push(new fabric.Point(_x, _y));
+          lines.push(line);
+
+          this.add(line);
+          this.selection = false;
+
+          // finalize the drawing for tripwire if we have 2 points
+          if (isDrawingTripWire && polygonPoints.length === 2) {
+            finalize();
+          }
+        }
+      });
+
+      canvas.on('mouse:up', function (evt) {
+        // on mouse up we want to recalculate new interaction
+        // for all objects, so we call setViewportTransform
+        this.setViewportTransform(this.viewportTransform);
+        if (this.isDragging) {
+          this.isDragging = false;
+          this.selection = true;
+        }
+      });
+
+      canvas.on('mouse:move', function (evt) {
+        if (this.isDragging) {
+          var e = evt.e;
+          var vpt = this.viewportTransform;
+          vpt[4] += e.clientX - this.lastPosX;
+          vpt[5] += e.clientY - this.lastPosY;
+          this.requestRenderAll();
+          this.lastPosX = e.clientX;
+          this.lastPosY = e.clientY;
+        }
+        if (lines.length && (isDrawing || isDrawingTripWire)) {
+          var _mouse = this.getPointer(evt.e);
+          lines[lines.length - 1].set({
+            x2: _mouse.x,
+            y2: _mouse.y
+          }).setCoords();
+          this.renderAll();
+        }
+      });
+
+      canvas.on('mouse:wheel', function (opt) {
+        var delta = opt.e.deltaY;
+        var zoom = canvas.getZoom();
+        zoom *= 0.999 ** delta;
+        if (zoom > 20) zoom = 20;
+        if (zoom < 0.01) zoom = 0.01;
+        canvas.zoomToPoint({
+          x: opt.e.offsetX,
+          y: opt.e.offsetY
+        }, zoom);
+        opt.e.preventDefault();
+        opt.e.stopPropagation();
+      });
+
+      function finalize() {
+        if (isDrawingTripWire) {
+          isDrawingTripWire = false;
+          canvas.add(makeTripwire(polygonPoints));
+        } else if (isDrawing) {
+          isDrawing = false;
+          canvas.add(makePolygon(polygonPoints)).renderAll();
+        }
+
+        canvas.selection = true;
+
+        lines.forEach(function (line) {
+          canvas.remove(line);
         });
 
-      let poly = []
-      transformedPoints.map(function (p) {
-        var pt = {
-          x: p.x,
-          y: p.y
-        };
+        lines.length = 0;
+        polygonPoints.length = 0;
+      }
 
-        poly.push(pt);
-      })
+      function makeTripwire(polygonPoints) {
+        let tripwire = new fabric.Polygon(polygonPoints.slice(), {
+          strokeWidth: 3,
+          selectable: true,
+          stroke: 'green'
+        });
 
-      return poly;
-    }
+        let tripwireArrowAngle = Math.atan2(polygonPoints[1].y - polygonPoints[0].y, polygonPoints[1].x - polygonPoints[0].x) * (180 / Math.PI);
+        let tripwireArrowHead = new fabric.Triangle({
+          left: polygonPoints[1].x,
+          top: polygonPoints[1].y,
+          originX: 'center',
+          originY: 'center',
+          angle: tripwireArrowAngle + 90, // Adjust the angle to point correctly
+          width: 10,
+          height: 15,
+          fill: 'green'
+        });
 
-    RED.comms.subscribe('region-editor', function (event, msg) {
-        let node = RED.nodes.node(msg.id);
-        node.background = msg.data;
-    });
+        // Calculate the middle point of the tripwire. This is going to be a reference point for the entry and exit vectors
+        let midPoint = new fabric.Point((polygonPoints[0].x + polygonPoints[1].x) / 2, (polygonPoints[0].y + polygonPoints[1].y) / 2);
 
-    RED.nodes.registerType('region-editor', {
-        category: 'visualize',
-        color: '#F3B567',
-        defaults: {
-            name: {value: ''},
-            json: {value: '[]', required: true},
-            regionsJson: {value: '[]', required: true},
-            tripwiresJson: {value: '[]', required: true},
-            background: {value: null, required: false},
-            imageProp: {value: 'image', required: false},
-            imagePropType: {value: 'msgPayload'}
-        },
-        inputs: 1,
-        outputs: 1,
-        icon: 'tn_dark.svg',
-        label: function () {
-            return this.name || 'region editor';
-        },
-        labelStyle: function () {
-            return this.name ? "node_label_italic" : "";
-        },
-        oneditprepare: function () {
-            const msgPayload = {
-                value: "msgPayload",
-                label: "msg.payload."
-            };
-            const msgEvent = {
-                value: "msgEvent",
-                label: "msg.payload.event."
-            };
-            $("#node-input-imageProp").typedInput({
-                default: "msgPayload",
-                types: ['msg', msgPayload, msgEvent],
-                typeField: "#node-input-imagePropType"
-            });
-            if (!$("#node-input-imageProp").typedInput('value').length) {
-                $("#node-input-imageProp").typedInput('type', 'msgEvent');
-                $("#node-input-imageProp").typedInput('value', 'image');
-            }
-// canvas Drawing
-            var node = this;
-            var background = node.background || 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAgAAAAIAQMAAAD+wSzIAAAABlBMVEX///+/v7+jQ3Y5AAAADklEQVQI12P4AIX8EAgALgAD/aNpbtEAAAAASUVORK5CYII';
-            var regionsJson = node.regionsJson || '[]';
-            var tripwiresJson = node.tripwiresJson || '[]';
-            var polygonPoints = [];
-            var lines = [];
-            var isDrawing = false;
-            var isDrawingTripWire = false;
-            if (!node.canvas) {
-                node.canvas = new fabric.Canvas('polyCanvas')
-            }
-            let canvas = node.canvas;
-            node.width = node.width || 800;
-            node.height = node.height || 600;
-            let width = node.width;
-            let height = node.height;
+        // Calculate the direction vector from the start point to the end point
+        let dirVector = new fabric.Point(polygonPoints[1].x - polygonPoints[0].x, polygonPoints[1].y - polygonPoints[0].y);
 
-            const img = new Image(background);
-            img.src = background;
-            img.onload = function () {
-                node.width = width = img.naturalWidth;
-                node.height = height = img.naturalHeight;
+        // Calculate the perpendicular vectors to the direction vector (tripwire)
+        let perpVector1 = new fabric.Point(-dirVector.y, dirVector.x);
+        let perpVector2 = new fabric.Point(dirVector.y, -dirVector.x);
 
-                canvas.setDimensions({width: width, height: height});
-                canvas.setBackgroundImage(background, canvas.renderAll.bind(canvas));
+        // Normalize the vectors for entry/exit display
+        let magnitude1 = Math.sqrt(perpVector1.x * perpVector1.x + perpVector1.y * perpVector1.y);
+        let magnitude2 = Math.sqrt(perpVector2.x * perpVector2.x + perpVector2.y * perpVector2.y);
+        let normalizedPerpVector1 = new fabric.Point(perpVector1.x / magnitude1, perpVector1.y / magnitude1);
+        let normalizedPerpVector2 = new fabric.Point(perpVector2.x / magnitude2, perpVector2.y / magnitude2);
 
-                let regions = JSON.parse(regionsJson);
-                for (let i = 0, len = regions.length; i < len; i++) {
-                    let relativePolygon = regions[i];
-                    let polygon = [];
-                    for (let j = 0; j < relativePolygon.length; j++) {
-                        polygon.push(fromRelative(relativePolygon[j], width, height));
-                    }
-                    canvas.add(makePolygon(polygon));
-                }
+        // Length of the arrow
+        let arrowLength = 30;
 
-                let tripwires = JSON.parse(tripwiresJson);
-              for (let i = 0, len = tripwires.length; i < len; i++) {
-                let relativeTripwire = tripwires[i];
-                let polygon = [];
-                for (let j = 0; j < relativeTripwire.length; j++) {
-                  polygon.push(fromRelative(relativeTripwire[j], width, height));
-                }
-                canvas.add(makeTripwire(polygon));
-              }
-            }
+        // Offset for arrow tip from midpoint
+        let arrowOffset = 10;
 
-            //
-            document.getElementById("add").onclick = function () {
-                if (isDrawing) {
-                    finalize();
-                } else {
-                    isDrawing = true;
-                }
-            };
+        // Calculate the entry and exit points
+        let exitPoint = new fabric.Point(midPoint.x + normalizedPerpVector1.x * arrowLength, midPoint.y + normalizedPerpVector1.y * arrowLength);
+        let entryPoint = new fabric.Point(midPoint.x + normalizedPerpVector2.x * arrowLength, midPoint.y + normalizedPerpVector2.y * arrowLength);
 
-          document.getElementById("add-tripwire").onclick = function () {
-            if (isDrawingTripWire) {
-              finalize();
-            } else {
-              isDrawingTripWire = true;
+        // Draw the vectors on the canvas
+        let entryVector = new fabric.Polyline([{x: midPoint.x, y: midPoint.y}, {x: entryPoint.x, y: entryPoint.y}], {
+          stroke: 'red',
+          strokeWidth: 2,
+          selectable: false
+        });
+        let exitVector = new fabric.Polyline([{x: midPoint.x, y: midPoint.y}, {x: exitPoint.x, y: exitPoint.y}], {
+          stroke: 'red',
+          strokeWidth: 2,
+          selectable: false
+        });
 
-              // reset the polygon drawing state
-              isDrawing = false;
-              polygonPoints.length = 0;
-              lines.length = 0;
-            }
+        // Add the text "Entry" and "Exit" next to the vectors
+        let entryText = new fabric.Text("Entry", {
+          left: entryPoint.x,
+          top: entryPoint.y,
+          fontSize: 20,
+          fill: 'red'
+        });
+        let exitText = new fabric.Text("Exit", {
+          left: exitPoint.x,
+          top: exitPoint.y,
+          fontSize: 20,
+          fill: 'red'
+        });
+
+        // Calculate positions for the arrowheads with offset
+        let adjustedEntryPoint = new fabric.Point(midPoint.x - normalizedPerpVector2.x * arrowOffset, midPoint.y - normalizedPerpVector2.y * arrowOffset);
+        let adjustedExitPoint = new fabric.Point(midPoint.x - normalizedPerpVector1.x * arrowOffset, midPoint.y - normalizedPerpVector1.y * arrowOffset);
+
+        // Add arrowheads to the vectors
+        let entryArrowAngle = Math.atan2(midPoint.y - entryPoint.y, midPoint.x - entryPoint.x) * (180 / Math.PI);
+        let entryArrowHead = new fabric.Triangle({
+          left: adjustedExitPoint.x,
+          top: adjustedExitPoint.y,
+          originX: 'center',
+          originY: 'center',
+          angle: entryArrowAngle + 90, // Adjust the angle to point correctly
+          width: 10,
+          height: 15,
+          fill: 'red'
+        });
+
+        let exitArrowAngle = Math.atan2(midPoint.y - exitPoint.y, midPoint.x - exitPoint.x) * (180 / Math.PI);
+        let exitArrowHead = new fabric.Triangle({
+          left: adjustedEntryPoint.x,
+          top: adjustedEntryPoint.y,
+          originX: 'center',
+          originY: 'center',
+          angle: exitArrowAngle + 90, // Adjust the angle to point correctly
+          width: 10,
+          height: 15,
+          fill: 'red'
+        });
+
+        // Create the entire group so that we can move the entire tripwire as a single entity
+        return new fabric.Group([tripwire, tripwireArrowHead, entryVector, exitVector, entryArrowHead, exitArrowHead, entryText, exitText], {
+          selectable: true // Make the group selectable
+        });
+      }
+
+      function makePolygon(polygonPoints) {
+
+        var left = fabric.util.array.min(polygonPoints, "x");
+        var top = fabric.util.array.min(polygonPoints, "y");
+
+        polygonPoints.push(new fabric.Point(polygonPoints[0].x, polygonPoints[0].y));
+
+        return new fabric.Polygon(polygonPoints.slice(), {
+          left: left,
+          top: top,
+          objectCaching: false,
+          fill: 'rgba(255,0,0,.5)',
+          stroke: 'black'
+        });
+      }
+
+      // define a function that can locate the controls.
+      // this function will be used both for drawing and for interaction.
+      function polygonPositionHandler(dim, finalMatrix, fabricObject) {
+        var x = (fabricObject.points[this.pointIndex].x - fabricObject.pathOffset.x),
+          y = (fabricObject.points[this.pointIndex].y - fabricObject.pathOffset.y);
+        return fabric.util.transformPoint({
+            x: x,
+            y: y
+          },
+          fabric.util.multiplyTransformMatrices(
+            fabricObject.canvas.viewportTransform,
+            fabricObject.calcTransformMatrix()
+          )
+        );
+      }
+
+      function getObjectSizeWithStroke(object) {
+        var stroke = new fabric.Point(
+          object.strokeUniform ? 1 / object.scaleX : 1,
+          object.strokeUniform ? 1 / object.scaleY : 1
+        ).multiply(object.strokeWidth);
+
+        return new fabric.Point(object.width + stroke.x, object.height + stroke.y);
+      }
+
+      // define a function that will define what the control does
+      // this function will be called on every mouse move after a control has been
+      // clicked and is being dragged.
+      // The function receive as argument the mouse event, the current trasnform object
+      // and the current position in canvas coordinate
+      // transform.target is a reference to the current object being transformed,
+      function actionHandler(eventData, transform, x, y) {
+        var polygon = transform.target,
+          currentControl = polygon.controls[polygon.__corner],
+          mouseLocalPosition = polygon.toLocalPoint(new fabric.Point(x, y), 'center', 'center'),
+          polygonBaseSize = getObjectSizeWithStroke(polygon),
+          size = polygon._getTransformedDimensions(0, 0),
+          finalPointPosition = {
+            x: mouseLocalPosition.x * polygonBaseSize.x / size.x + polygon.pathOffset.x,
+            y: mouseLocalPosition.y * polygonBaseSize.y / size.y + polygon.pathOffset.y
           };
+        polygon.points[currentControl.pointIndex] = finalPointPosition;
+        return true;
+      }
 
-            //
-            document.getElementById("edit").onclick = function () {
-                if (!canvas.getActiveObject()) {
-                    return;
-                }
-
-                var poly = canvas.getActiveObject();
-                canvas.setActiveObject(poly);
-                poly.edit = !poly.edit;
-                if (poly.edit) {
-                    var lastControl = poly.points.length - 1;
-                    poly.cornerStyle = 'circle';
-                    poly.cornerColor = 'rgba(0,0,255,0.5)';
-                    poly.controls = poly.points.reduce(function (acc, point, index) {
-                        acc['p' + index] = new fabric.Control({
-                            positionHandler: polygonPositionHandler,
-                            actionHandler: anchorWrapper(index > 0 ? index - 1 : lastControl, actionHandler),
-                            actionName: 'modifyPolygon',
-                            pointIndex: index
-                        });
-                        return acc;
-                    }, {});
-                } else {
-                    poly.cornerColor = 'blue';
-                    poly.cornerStyle = 'rect';
-                    poly.controls = fabric.Object.prototype.controls;
-                }
-                poly.hasBorders = !poly.edit;
-                canvas.requestRenderAll();
-            }
-
-            //
-            document.getElementById("trash").onclick = function () {
-                if (!canvas.getActiveObject()) {
-                    return;
-                }
-
-                var poly = canvas.getActiveObject();
-                canvas.remove(poly);
-            };
-
-            //
-            fabric.util.addListener(window, "dblclick", function () {
-                if (isDrawing) {
-                    finalize();
-                }
-            });
-
-//
-            fabric.util.addListener(window, "keyup", function (evt) {
-                if (evt.which === 13 && isDrawing) {
-                    finalize();
-                }
-            });
-
-            canvas.on('mouse:down', function (evt) {
-                if (evt.e.altKey === true) {
-                    this.isDragging = true;
-                    this.selection = false;
-                    this.lastPosX = evt.e.clientX;
-                    this.lastPosY = evt.e.clientY;
-                }
-                if (isDrawing || isDrawingTripWire) {
-                    var _mouse = this.getPointer(evt.e);
-                    var _x = _mouse.x;
-                    var _y = _mouse.y;
-                    var line = new fabric.Line([_x, _y, _x, _y], {
-                        strokeWidth: 1,
-                        selectable: false,
-                        stroke: isDrawing ? 'red' : 'green'
-                    });
-
-                    polygonPoints.push(new fabric.Point(_x, _y));
-                    lines.push(line);
-
-                    this.add(line);
-                    this.selection = false;
-
-                    // finalize the drawing for tripwire if we have 2 points
-                    if (isDrawingTripWire && polygonPoints.length === 2) {
-                      finalize();
-                    }
-                }
-            });
-
-            canvas.on('mouse:up', function (evt) {
-                // on mouse up we want to recalculate new interaction
-                // for all objects, so we call setViewportTransform
-                this.setViewportTransform(this.viewportTransform);
-                if (this.isDragging) {
-                    this.isDragging = false;
-                    this.selection = true;
-                }
-            });
-
-            canvas.on('mouse:move', function (evt) {
-                if (this.isDragging) {
-                    var e = evt.e;
-                    var vpt = this.viewportTransform;
-                    vpt[4] += e.clientX - this.lastPosX;
-                    vpt[5] += e.clientY - this.lastPosY;
-                    this.requestRenderAll();
-                    this.lastPosX = e.clientX;
-                    this.lastPosY = e.clientY;
-                }
-                if (lines.length && (isDrawing || isDrawingTripWire)) {
-                    var _mouse = this.getPointer(evt.e);
-                    lines[lines.length - 1].set({
-                        x2: _mouse.x,
-                        y2: _mouse.y
-                    }).setCoords();
-                    this.renderAll();
-                }
-            });
-
-            canvas.on('mouse:wheel', function (opt) {
-                var delta = opt.e.deltaY;
-                var zoom = canvas.getZoom();
-                zoom *= 0.999 ** delta;
-                if (zoom > 20) zoom = 20;
-                if (zoom < 0.01) zoom = 0.01;
-                canvas.zoomToPoint({
-                    x: opt.e.offsetX,
-                    y: opt.e.offsetY
-                }, zoom);
-                opt.e.preventDefault();
-                opt.e.stopPropagation();
-            });
-
-//
-            function finalize() {
-              if (isDrawingTripWire) {
-                isDrawingTripWire = false;
-                canvas.add(makeTripwire(polygonPoints));
-              } else if (isDrawing) {
-                isDrawing = false;
-                canvas.add(makePolygon(polygonPoints)).renderAll();
-              }
-
-              canvas.selection = true;
-
-              lines.forEach(function (line) {
-                canvas.remove(line);
-              });
-
-              lines.length = 0;
-              polygonPoints.length = 0;
-            }
-
-            function makeTripwire(polygonPoints) {
-              let tripwire = new fabric.Polygon(polygonPoints.slice(), {
-                strokeWidth: 3,
-                selectable: true,
-                stroke: 'green'
-              });
-
-              let tripwireArrowAngle = Math.atan2(polygonPoints[1].y - polygonPoints[0].y, polygonPoints[1].x - polygonPoints[0].x) * (180 / Math.PI);
-              let tripwireArrowHead = new fabric.Triangle({
-                left: polygonPoints[1].x,
-                top: polygonPoints[1].y,
-                originX: 'center',
-                originY: 'center',
-                angle: tripwireArrowAngle + 90, // Adjust the angle to point correctly
-                width: 10,
-                height: 15,
-                fill: 'green'
-              });
-
-              // Calculate the middle point of the tripwire. This is going to be a reference point for the entry and exit vectors
-              let midPoint = new fabric.Point((polygonPoints[0].x + polygonPoints[1].x) / 2, (polygonPoints[0].y + polygonPoints[1].y) / 2);
-
-              // Calculate the direction vector from the start point to the end point
-              let dirVector = new fabric.Point(polygonPoints[1].x - polygonPoints[0].x, polygonPoints[1].y - polygonPoints[0].y);
-
-              // Calculate the perpendicular vectors to the direction vector (tripwire)
-              let perpVector1 = new fabric.Point(-dirVector.y, dirVector.x);
-              let perpVector2 = new fabric.Point(dirVector.y, -dirVector.x);
-
-              // Normalize the vectors for entry/exit display
-              let magnitude1 = Math.sqrt(perpVector1.x * perpVector1.x + perpVector1.y * perpVector1.y);
-              let magnitude2 = Math.sqrt(perpVector2.x * perpVector2.x + perpVector2.y * perpVector2.y);
-              let normalizedPerpVector1 = new fabric.Point(perpVector1.x / magnitude1, perpVector1.y / magnitude1);
-              let normalizedPerpVector2 = new fabric.Point(perpVector2.x / magnitude2, perpVector2.y / magnitude2);
-
-              // Length of the arrow
-              let arrowLength = 30;
-
-              // Offset for arrow tip from midpoint
-              let arrowOffset = 10;
-
-              // Calculate the entry and exit points
-              let exitPoint = new fabric.Point(midPoint.x + normalizedPerpVector1.x * arrowLength, midPoint.y + normalizedPerpVector1.y * arrowLength);
-              let entryPoint = new fabric.Point(midPoint.x + normalizedPerpVector2.x * arrowLength, midPoint.y + normalizedPerpVector2.y * arrowLength);
-
-              // Draw the vectors on the canvas
-              let entryVector = new fabric.Polyline([{x: midPoint.x, y: midPoint.y}, {x: entryPoint.x, y: entryPoint.y}], {
-                stroke: 'red',
-                strokeWidth: 2,
-                selectable: false
-              });
-              let exitVector = new fabric.Polyline([{x: midPoint.x, y: midPoint.y}, {x: exitPoint.x, y: exitPoint.y}], {
-                stroke: 'red',
-                strokeWidth: 2,
-                selectable: false
-              });
-
-              // Add the text "Entry" and "Exit" next to the vectors
-              let entryText = new fabric.Text("Entry", {
-                left: entryPoint.x,
-                top: entryPoint.y,
-                fontSize: 20,
-                fill: 'red'
-              });
-              let exitText = new fabric.Text("Exit", {
-                left: exitPoint.x,
-                top: exitPoint.y,
-                fontSize: 20,
-                fill: 'red'
-              });
-
-              // Calculate positions for the arrowheads with offset
-              let adjustedEntryPoint = new fabric.Point(midPoint.x - normalizedPerpVector2.x * arrowOffset, midPoint.y - normalizedPerpVector2.y * arrowOffset);
-              let adjustedExitPoint = new fabric.Point(midPoint.x - normalizedPerpVector1.x * arrowOffset, midPoint.y - normalizedPerpVector1.y * arrowOffset);
-
-              // Add arrowheads to the vectors
-              let entryArrowAngle = Math.atan2(midPoint.y - entryPoint.y, midPoint.x - entryPoint.x) * (180 / Math.PI);
-              let entryArrowHead = new fabric.Triangle({
-                left: adjustedExitPoint.x,
-                top: adjustedExitPoint.y,
-                originX: 'center',
-                originY: 'center',
-                angle: entryArrowAngle + 90, // Adjust the angle to point correctly
-                width: 10,
-                height: 15,
-                fill: 'red'
-              });
-
-              let exitArrowAngle = Math.atan2(midPoint.y - exitPoint.y, midPoint.x - exitPoint.x) * (180 / Math.PI);
-              let exitArrowHead = new fabric.Triangle({
-                left: adjustedEntryPoint.x,
-                top: adjustedEntryPoint.y,
-                originX: 'center',
-                originY: 'center',
-                angle: exitArrowAngle + 90, // Adjust the angle to point correctly
-                width: 10,
-                height: 15,
-                fill: 'red'
-              });
-
-              // Create the entire group so that we can move the entire tripwire as a single entity
-              return new fabric.Group([tripwire, tripwireArrowHead, entryVector, exitVector, entryArrowHead, exitArrowHead, entryText, exitText], {
-                selectable: true // Make the group selectable
-              });
-            }
-
-            function makePolygon(polygonPoints) {
-
-                var left = fabric.util.array.min(polygonPoints, "x");
-                var top = fabric.util.array.min(polygonPoints, "y");
-
-                polygonPoints.push(new fabric.Point(polygonPoints[0].x, polygonPoints[0].y));
-
-                return new fabric.Polygon(polygonPoints.slice(), {
-                    left: left,
-                    top: top,
-                    objectCaching: false,
-                    fill: 'rgba(255,0,0,.5)',
-                    stroke: 'black'
-                });
-            }
-
-// define a function that can locate the controls.
-// this function will be used both for drawing and for interaction.
-            function polygonPositionHandler(dim, finalMatrix, fabricObject) {
-                var x = (fabricObject.points[this.pointIndex].x - fabricObject.pathOffset.x),
-                    y = (fabricObject.points[this.pointIndex].y - fabricObject.pathOffset.y);
-                return fabric.util.transformPoint({
-                        x: x,
-                        y: y
-                    },
-                    fabric.util.multiplyTransformMatrices(
-                        fabricObject.canvas.viewportTransform,
-                        fabricObject.calcTransformMatrix()
-                    )
-                );
-            }
-
-            function getObjectSizeWithStroke(object) {
-                var stroke = new fabric.Point(
-                    object.strokeUniform ? 1 / object.scaleX : 1,
-                    object.strokeUniform ? 1 / object.scaleY : 1
-                ).multiply(object.strokeWidth);
-                return new fabric.Point(object.width + stroke.x, object.height + stroke.y);
-            }
-
-// define a function that will define what the control does
-// this function will be called on every mouse move after a control has been
-// clicked and is being dragged.
-// The function receive as argument the mouse event, the current trasnform object
-// and the current position in canvas coordinate
-// transform.target is a reference to the current object being transformed,
-            function actionHandler(eventData, transform, x, y) {
-                var polygon = transform.target,
-                    currentControl = polygon.controls[polygon.__corner],
-                    mouseLocalPosition = polygon.toLocalPoint(new fabric.Point(x, y), 'center', 'center'),
-                    polygonBaseSize = getObjectSizeWithStroke(polygon),
-                    size = polygon._getTransformedDimensions(0, 0),
-                    finalPointPosition = {
-                        x: mouseLocalPosition.x * polygonBaseSize.x / size.x + polygon.pathOffset.x,
-                        y: mouseLocalPosition.y * polygonBaseSize.y / size.y + polygon.pathOffset.y
-                    };
-                polygon.points[currentControl.pointIndex] = finalPointPosition;
-                return true;
-            }
-
-// define a function that can keep the polygon in the same position when we change its
-// width/height/top/left.
-            function anchorWrapper(anchorIndex, fn) {
-                return function (eventData, transform, x, y) {
-                    var fabricObject = transform.target,
-                        absolutePoint = fabric.util.transformPoint({
-                            x: (fabricObject.points[anchorIndex].x - fabricObject.pathOffset.x),
-                            y: (fabricObject.points[anchorIndex].y - fabricObject.pathOffset.y),
-                        }, fabricObject.calcTransformMatrix()),
-                        actionPerformed = fn(eventData, transform, x, y),
-                        newDim = fabricObject._setPositionDimensions({}),
-                        polygonBaseSize = getObjectSizeWithStroke(fabricObject),
-                        newX = (fabricObject.points[anchorIndex].x - fabricObject.pathOffset.x) / polygonBaseSize.x,
-                        newY = (fabricObject.points[anchorIndex].y - fabricObject.pathOffset.y) / polygonBaseSize.y;
-                    fabricObject.setPositionByOrigin(absolutePoint, newX + 0.5, newY + 0.5);
-                    return actionPerformed;
-                }
-            }
-        },
-        oneditsave: function () {
-            this.regionsJson = JSON.stringify(collate(this.canvas, this.width, this.height, 'polygon'));
-            var textAreaRegionsJson = document.getElementById("node-input-regionsJson");
-            textAreaRegionsJson.value = this.regionsJson;
-
-            this.tripwiresJson = JSON.stringify(collate(this.canvas, this.width, this.height, 'group'));
-            var textAreaTripwiresJson = document.getElementById("node-input-tripwiresJson");
-            textAreaTripwiresJson.value = this.tripwiresJson;
-
-            this.canvas = null;
-        },
-        oneditcancel: function() {
-            this.canvas = null;
+      // define a function that can keep the polygon in the same position when we change its
+      // width/height/top/left.
+      function anchorWrapper(anchorIndex, fn) {
+        return function (eventData, transform, x, y) {
+          var fabricObject = transform.target,
+            absolutePoint = fabric.util.transformPoint({
+              x: (fabricObject.points[anchorIndex].x - fabricObject.pathOffset.x),
+              y: (fabricObject.points[anchorIndex].y - fabricObject.pathOffset.y),
+            }, fabricObject.calcTransformMatrix()),
+            actionPerformed = fn(eventData, transform, x, y),
+            newDim = fabricObject._setPositionDimensions({}),
+            polygonBaseSize = getObjectSizeWithStroke(fabricObject),
+            newX = (fabricObject.points[anchorIndex].x - fabricObject.pathOffset.x) / polygonBaseSize.x,
+            newY = (fabricObject.points[anchorIndex].y - fabricObject.pathOffset.y) / polygonBaseSize.y;
+          fabricObject.setPositionByOrigin(absolutePoint, newX + 0.5, newY + 0.5);
+          return actionPerformed;
         }
-    });
+      }
+    },
+    oneditsave: function () {
+      this.regionsJson = JSON.stringify(collate(this.canvas, this.width, this.height, 'polygon'));
+      var textAreaRegionsJson = document.getElementById("node-input-regionsJson");
+      textAreaRegionsJson.value = this.regionsJson;
+
+      this.tripwiresJson = JSON.stringify(collate(this.canvas, this.width, this.height, 'group'));
+      var textAreaTripwiresJson = document.getElementById("node-input-tripwiresJson");
+      textAreaTripwiresJson.value = this.tripwiresJson;
+
+      this.canvas = null;
+    },
+    oneditcancel: function () {
+      this.canvas = null;
+    }
+  });
 </script>

--- a/src/region-editor.html
+++ b/src/region-editor.html
@@ -427,8 +427,6 @@
                   height: 15,
                   fill: 'green'
                 });
-                canvas.add(tripwire);
-                canvas.add(tripwireArrowHead);
 
                 // Calculate the middle point of the tripwire. This is going to be a reference point for the entry and exit vectors
                 let midPoint = new fabric.Point((polygonPoints[0].x + polygonPoints[1].x) / 2, (polygonPoints[0].y + polygonPoints[1].y) / 2);
@@ -446,25 +444,27 @@
                 let normalizedPerpVector1 = new fabric.Point(perpVector1.x / magnitude1, perpVector1.y / magnitude1);
                 let normalizedPerpVector2 = new fabric.Point(perpVector2.x / magnitude2, perpVector2.y / magnitude2);
 
+                // Length of the arrow
+                let arrowLength = 30;
+
+                // Offset for arrow tip from midpoint
+                let arrowOffset = 10;
+
                 // Calculate the entry and exit points
-                let arrowLength = 30; // Length of the arrow
-                let arrowOffset = 10; // Offset for arrow tip from midpoint
                 let exitPoint = new fabric.Point(midPoint.x + normalizedPerpVector1.x * arrowLength, midPoint.y + normalizedPerpVector1.y * arrowLength);
                 let entryPoint = new fabric.Point(midPoint.x + normalizedPerpVector2.x * arrowLength, midPoint.y + normalizedPerpVector2.y * arrowLength);
 
                 // Draw the vectors on the canvas
-                let entryVector = new fabric.Line([midPoint.x, midPoint.y, entryPoint.x, entryPoint.y], {
+                let entryVector = new fabric.Polyline([{x: midPoint.x, y: midPoint.y}, {x: entryPoint.x, y: entryPoint.y}], {
                   stroke: 'red',
                   strokeWidth: 2,
                   selectable: false
                 });
-                let exitVector = new fabric.Line([midPoint.x, midPoint.y, exitPoint.x, exitPoint.y], {
+                let exitVector = new fabric.Polyline([{x: midPoint.x, y: midPoint.y}, {x: exitPoint.x, y: exitPoint.y}], {
                   stroke: 'red',
                   strokeWidth: 2,
                   selectable: false
                 });
-                canvas.add(entryVector);
-                canvas.add(exitVector);
 
                 // Add the text "Entry" and "Exit" next to the vectors
                 let entryText = new fabric.Text("Entry", {
@@ -479,39 +479,43 @@
                   fontSize: 20,
                   fill: 'red'
                 });
-                canvas.add(entryText);
-                canvas.add(exitText);
 
                 // Calculate positions for the arrowheads with offset
                 let adjustedEntryPoint = new fabric.Point(midPoint.x - normalizedPerpVector2.x * arrowOffset, midPoint.y - normalizedPerpVector2.y * arrowOffset);
                 let adjustedExitPoint = new fabric.Point(midPoint.x - normalizedPerpVector1.x * arrowOffset, midPoint.y - normalizedPerpVector1.y * arrowOffset);
 
                 // Add arrowheads to the vectors
-                let arrowAngle1 = Math.atan2(midPoint.y - entryPoint.y, midPoint.x - entryPoint.x) * (180 / Math.PI);
-                let arrowHead1 = new fabric.Triangle({
+                let entryArrowAngle = Math.atan2(midPoint.y - entryPoint.y, midPoint.x - entryPoint.x) * (180 / Math.PI);
+                let entryArrowHead = new fabric.Triangle({
                   left: adjustedExitPoint.x,
                   top: adjustedExitPoint.y,
                   originX: 'center',
                   originY: 'center',
-                  angle: arrowAngle1 + 90, // Adjust the angle to point correctly
+                  angle: entryArrowAngle + 90, // Adjust the angle to point correctly
                   width: 10,
                   height: 15,
                   fill: 'red'
                 });
-                canvas.add(arrowHead1);
 
-                let arrowAngle2 = Math.atan2(midPoint.y - exitPoint.y, midPoint.x - exitPoint.x) * (180 / Math.PI);
-                let arrowHead2 = new fabric.Triangle({
+                let exitArrowAngle = Math.atan2(midPoint.y - exitPoint.y, midPoint.x - exitPoint.x) * (180 / Math.PI);
+                let exitArrowHead = new fabric.Triangle({
                   left: adjustedEntryPoint.x,
                   top: adjustedEntryPoint.y,
                   originX: 'center',
                   originY: 'center',
-                  angle: arrowAngle2 + 90, // Adjust the angle to point correctly
+                  angle: exitArrowAngle + 90, // Adjust the angle to point correctly
                   width: 10,
                   height: 15,
                   fill: 'red'
                 });
-                canvas.add(arrowHead2);
+
+                // Create the entire group so that we can move the entire tripwire as a single entity
+                let tripwireGroup = new fabric.Group([tripwire, tripwireArrowHead, entryVector, exitVector, entryArrowHead, exitArrowHead, entryText, exitText], {
+                  selectable: true // Make the group selectable
+                });
+
+                // Add the group to the canvas
+                canvas.add(tripwireGroup);
               } else if (isDrawing) {
                 isDrawing = false;
                 canvas.add(makePolygon(polygonPoints)).renderAll();

--- a/src/region-editor.js
+++ b/src/region-editor.js
@@ -2,12 +2,14 @@ const isBase64 = require("is-base64");
 module.exports = function (RED) {
     "use strict";
 
-    function RegionEditor(n) {
-        RED.nodes.createNode(this, n);
+    function RegionEditor(config) {
+        RED.nodes.createNode(this, config);
         let node = this;
-        let json = n.json || '{}';
-        node.imageProp = n.imageProp || 'image';
-        node.imagePropType = n.imagePropType || 'msgPayload';
+
+        node.regionsJson = config.regionsJson;
+        node.tripwiresJson = config.tripwiresJson;
+        node.imageProp = config.imageProp;
+        node.imagePropType = config.imagePropType;
 
 
         function getImageFromMsg(msg) {
@@ -53,9 +55,11 @@ module.exports = function (RED) {
             if (image && validateImageFormat(image)) {
                 sendDataToClient(image, msg);
                 if (node.imagePropType === 'msg') {
-                    msg['regions'] = JSON.parse(json);
+                    msg['regions'] = JSON.parse(node.regionsJson);
+                    msg['tripwires'] = JSON.parse(node.tripwiresJson);
                 } else {
-                    msg.payload['regions'] = JSON.parse(json);
+                    msg.payload['regions'] = JSON.parse(node.regionsJson);
+                    msg.payload['tripwires'] = JSON.parse(node.tripwiresJson);
                 }
             } else {
                 node.error("Image is not in mime base64 encoded format!", msg);

--- a/src/region-editor.js
+++ b/src/region-editor.js
@@ -1,73 +1,73 @@
 const isBase64 = require("is-base64");
 module.exports = function (RED) {
-    "use strict";
+  "use strict";
 
-    function RegionEditor(config) {
-        RED.nodes.createNode(this, config);
-        let node = this;
+  function RegionEditor(config) {
+    RED.nodes.createNode(this, config);
+    let node = this;
 
-        node.regionsJson = config.regionsJson;
-        node.tripwiresJson = config.tripwiresJson;
-        node.imageProp = config.imageProp;
-        node.imagePropType = config.imagePropType;
+    node.regionsJson = config.regionsJson;
+    node.tripwiresJson = config.tripwiresJson;
+    node.imageProp = config.imageProp;
+    node.imagePropType = config.imagePropType;
 
 
-        function getImageFromMsg(msg) {
-            if (node.imagePropType === 'msg') {
-                return msg[node.imageProp];
-            } else if (node.imagePropType === 'msgPayload') {
-                return msg.payload[node.imageProp];
-            } else {
-                return msg.payload.event[node.imageProp];
-            }
-        }
-
-        function validateImageFormat(data) {
-            //if image is base64, convert it to a buffer
-            let isString = typeof data === 'string';
-            let hasMime = false, isBase64Image = false
-            if (isString) {
-                hasMime = data.startsWith("data:");
-                isBase64Image = isBase64(data, {mimeRequired: hasMime});
-            }
-            if (isString && isBase64Image) {
-                return true;
-            }
-            return false;
-        }
-
-        function sendDataToClient(data, msg) {
-            let d = {
-                id: node.id,
-            };
-            if (data) {
-                d.data = data;
-            }
-            try {
-                RED.comms.publish("region-editor", d);
-            } catch (e) {
-                node.error("Error sending image to region editor", msg);
-            }
-        }
-
-        this.on("input", function (msg, send, done) {
-            let image = getImageFromMsg(msg);
-            if (image && validateImageFormat(image)) {
-                sendDataToClient(image, msg);
-                if (node.imagePropType === 'msg') {
-                    msg['regions'] = JSON.parse(node.regionsJson);
-                    msg['tripwires'] = JSON.parse(node.tripwiresJson);
-                } else {
-                    msg.payload['regions'] = JSON.parse(node.regionsJson);
-                    msg.payload['tripwires'] = JSON.parse(node.tripwiresJson);
-                }
-            } else {
-                node.error("Image is not in mime base64 encoded format!", msg);
-            }
-            send(msg);
-            done();
-        });
+    function getImageFromMsg(msg) {
+      if (node.imagePropType === 'msg') {
+        return msg[node.imageProp];
+      } else if (node.imagePropType === 'msgPayload') {
+        return msg.payload[node.imageProp];
+      } else {
+        return msg.payload.event[node.imageProp];
+      }
     }
 
-    RED.nodes.registerType("region-editor", RegionEditor);
+    function validateImageFormat(data) {
+      //if image is base64, convert it to a buffer
+      let isString = typeof data === 'string';
+      let hasMime = false, isBase64Image = false
+      if (isString) {
+        hasMime = data.startsWith("data:");
+        isBase64Image = isBase64(data, {mimeRequired: hasMime});
+      }
+      if (isString && isBase64Image) {
+        return true;
+      }
+      return false;
+    }
+
+    function sendDataToClient(data, msg) {
+      let d = {
+        id: node.id,
+      };
+      if (data) {
+        d.data = data;
+      }
+      try {
+        RED.comms.publish("region-editor", d);
+      } catch (e) {
+        node.error("Error sending image to region editor", msg);
+      }
+    }
+
+    this.on("input", function (msg, send, done) {
+      let image = getImageFromMsg(msg);
+      if (image && validateImageFormat(image)) {
+        sendDataToClient(image, msg);
+        if (node.imagePropType === 'msg') {
+          msg['regions'] = JSON.parse(node.regionsJson);
+          msg['tripwires'] = JSON.parse(node.tripwiresJson);
+        } else {
+          msg.payload['regions'] = JSON.parse(node.regionsJson);
+          msg.payload['tripwires'] = JSON.parse(node.tripwiresJson);
+        }
+      } else {
+        node.error("Image is not in mime base64 encoded format!", msg);
+      }
+      send(msg);
+      done();
+    });
+  }
+
+  RED.nodes.registerType("region-editor", RegionEditor);
 }


### PR DESCRIPTION
### Overview
* Implemented drawing tripwire. It also draws supporting graphics, such as entry/exit vectors, arrow heads and text. But the JSON only contains the tripwire starting and endpoint.
* Added tool icon for initiating tripwire drawing and update icon for region drawing.
* Output messages now contain also `tripwires` field:
```
{
    "image": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAA......",
    "regions": [
        [
            {
                "x": 0.11762496948242188,
                "y": 0.22999452051406952
            },
            {
                "x": 0.07887496948242187,
                "y": 0.33836394986199014
            },
            {
                "x": 0.19512496948242186,
                "y": 0.32252534095729407
            },
            {
                "x": 0.29512496948242184,
                "y": 0.26583979329838175
            },
            {
                "x": 0.17262496948242187,
                "y": 0.23082813150905354
            },
            {
                "x": 0.2676249694824218,
                "y": 0.1724753618601732
            },
            {
                "x": 0.037624969482421874,
                "y": 0.1157898142012609
            }
        ],
        [
            {
                "x": 0.8626249694824218,
                "y": 0.2925149277758897
            },
            {
                "x": 0.6651249694824218,
                "y": 0.3992171351338423
            },
            {
                "x": 0.9363749694824218,
                "y": 0.46924045871249875
            },
            {
                "x": 0.9401249694824219,
                "y": 0.2758427078762096
            }
        ]
    ],
    "tripwires": [
        [
            {
                "x": 0.2840081467052135,
                "y": 0.39763253794652054
            },
            {
                "x": 0.7565081467052136,
                "y": 0.2625875567591119
            }
        ],
        [
            {
                "x": 0.22347530837463978,
                "y": 0.10639937703679662
            },
            {
                "x": -0.02402469162536022,
                "y": 0.048880218382900305
            }
        ],
        [
            {
                "x": 0.10498860165688108,
                "y": 1.0482831901767515
            },
            {
                "x": 0.6220318644734967,
                "y": 1.0419852840760562
            }
        ]
    ]
}
```
![Screenshot 2024-05-17 at 15 54 54](https://github.com/teknoir/node-red-teknoir-visualize/assets/1238022/4d55d033-94c0-4b34-8e84-6512d33ced0b)
